### PR TITLE
Resolved the SSL Issue

### DIFF
--- a/spring-cloud-starter-stream-sink-task-launcher-cloudfoundry/README.adoc
+++ b/spring-cloud-starter-stream-sink-task-launcher-cloudfoundry/README.adoc
@@ -48,7 +48,7 @@ sent to the `cftask` sink (which is a Cloud Foundry TaskLauncher).  For example:
 
 *Deploy The Stream*
 
-`stream deploy task-stream --properties "app.cftask.spring_cloud_deployer_cloudfoundry_url=https://api.local.pcfdev.io, app.cftask.spring_cloud_deployer_cloudfoundry_org=pcfdev-org, app.cftask.spring_cloud_deployer_cloudfoundry_space=pcfdev-space, app.cftask.spring_cloud_deployer_cloudfoundry_domain=local.pcfdev.io, app.cftask.spring_cloud_deployer_cloudfoundry_username=admin, app.cftask.spring_cloud_deployer_cloudfoundry_password=admin, app.cftask.spring_cloud_deployer_cloudfoundry_skipSslValidation=true, app.cftask.spring_cloud_deployer_cloudfoundry_services=mysql, app.cftask.spring_cloud_deployer_cloudfoundry_taskTimeout=300"`
+`stream deploy task-stream --properties "app.cftask.spring.cloud.deployer.cloudfoundry.url=https://api.local.pcfdev.io, app.cftask.spring.cloud.deployer.cloudfoundry.org=pcfdev-org, app.cftask.spring.cloud.deployer.cloudfoundry.space=pcfdev-space, app.cftask.spring.cloud.deployer.cloudfoundry.domain=local.pcfdev.io, app.cftask.spring.cloud.deployer.cloudfoundry.username=admin, app.cftask.spring.cloud.deployer.cloudfoundry.password=admin, app.cftask.spring.cloud.deployer.cloudfoundry.skipSslValidation=true, app.cftask.spring.cloud.deployer.cloudfoundry.services=mysql, app.cftask.spring.cloud.deployer.cloudfoundry.taskTimeout=300"`
 
 *Test The Stream*
 
@@ -57,6 +57,15 @@ sent to the `cftask` sink (which is a Cloud Foundry TaskLauncher).  For example:
 This example deploys to pcfdev using a mysql database service with the
 service name of `mysql`.  Also we can see that there is a taskTimeout of 300
 seconds for staging the task.
+
+== Remote Repositories
+If the tasklauncher-cloudfoundry app needs to resolve artifacts from remote
+maven repositories, be sure to set the `--maven.remote-repositories` properties.
+For example:
+
+```
+stream create foo --definition "triggertask --uri=maven://org.springframework.cloud.task.app:timestamp-task:jar:1.0.1.RELEASE --fixed-delay=5 | task-launcher-local --maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot"
+```
 
 //tag::configuration-properties[]
 $$spring.cloud.deployer.cloudfoundry.api-timeout$$:: $$Timeout for blocking API calls, in seconds.$$ *($$Long$$, default: `$$30$$`)*

--- a/spring-cloud-starter-stream-sink-task-launcher-cloudfoundry/pom.xml
+++ b/spring-cloud-starter-stream-sink-task-launcher-cloudfoundry/pom.xml
@@ -10,12 +10,6 @@
 
 	<artifactId>spring-cloud-starter-stream-sink-task-launcher-cloudfoundry</artifactId>
 
-	<properties>
-		<io-projectreactor-core.version>3.0.2.RELEASE</io-projectreactor-core.version>
-		<io-projectreactor-ipc.version>0.5.1.RELEASE</io-projectreactor-ipc.version>
-		<io-netty-all.version>4.1.5.Final</io-netty-all.version>
-	</properties>
-
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
@@ -38,16 +32,8 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>io.netty</groupId>
-			<artifactId>netty-all</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>io.projectreactor.ipc</groupId>
-			<artifactId>reactor-netty</artifactId>
 		</dependency>
 	</dependencies>
 
@@ -70,25 +56,7 @@
 						<version>${project.version}</version>
 					</bom>
 					<generatedApps>
-						<task-launcher-cloudfoundry-sink>
-							<forceDependencies>
-								<dependency>
-									<groupId>io.projectreactor</groupId>
-									<artifactId>reactor-core</artifactId>
-									<version>${io-projectreactor-core.version}</version>
-								</dependency>
-								<dependency>
-									<groupId>io.projectreactor.ipc</groupId>
-									<artifactId>reactor-netty</artifactId>
-									<version>${io-projectreactor-ipc.version}</version>
-								</dependency>
-								<dependency>
-									<groupId>io.netty</groupId>
-									<artifactId>netty-all</artifactId>
-									<version>${io-netty-all.version}</version>
-								</dependency>
-							</forceDependencies>
-						</task-launcher-cloudfoundry-sink>
+						<task-launcher-cloudfoundry-sink/>
 					</generatedApps>
 				</configuration>
 			</plugin>

--- a/tasklauncher-cloudfoundry-app-dependencies/pom.xml
+++ b/tasklauncher-cloudfoundry-app-dependencies/pom.xml
@@ -1,33 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.springframework.cloud.stream.app</groupId>
     <artifactId>tasklauncher-cloudfoundry-app-dependencies</artifactId>
     <version>1.2.0.BUILD-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>tasklauncher-cloudfoundry-app-dependencies</name>
-    <description>Spring Cloud Stream tasklauncher cloudfoundry App Dependencies</description>
+    <description>Spring Cloud Stream tasklauncher cloudfoundry App
+        Dependencies
+    </description>
 
     <parent>
-	<artifactId>spring-cloud-dependencies-parent</artifactId>
+        <artifactId>spring-cloud-dependencies-parent</artifactId>
         <groupId>org.springframework.cloud</groupId>
         <version>1.2.1.RELEASE</version>
-        <relativePath />
+        <relativePath/>
     </parent>
 
     <properties>
-        <spring-cloud-deployer-cloudfoundry.version>1.1.0.RELEASE</spring-cloud-deployer-cloudfoundry.version>
-        <spring.cloud.task.version>1.1.2.RELEASE</spring.cloud.task.version>
-        <reactor.version>3.0.4.RELEASE</reactor.version>
-        <reactor-netty.version>0.6.0.RELEASE</reactor-netty.version>
-        <netty.version>4.1.5.Final</netty.version>
+        <spring-cloud-deployer-cloudfoundry.version>1.1.1.RELEASE
+        </spring-cloud-deployer-cloudfoundry.version>
+        <spring.cloud.task.version>1.1.2.BUILD-SNAPSHOT
+        </spring.cloud.task.version>
+        <reactor.version>3.0.5.RELEASE</reactor.version>
+        <spring-cloud-deployer-spi.version>1.1.4.RELEASE
+        </spring-cloud-deployer-spi.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>org.springframework.cloud.stream.app</groupId>
-                <artifactId>spring-cloud-starter-stream-sink-task-launcher-cloudfoundry</artifactId>
+                <artifactId>
+                    spring-cloud-starter-stream-sink-task-launcher-cloudfoundry
+                </artifactId>
                 <version>1.2.0.BUILD-SNAPSHOT</version>
             </dependency>
             <dependency>
@@ -41,89 +49,82 @@
                 <version>${spring-cloud-deployer-cloudfoundry.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-all</artifactId>
-                <version>${netty.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
                 <groupId>io.projectreactor</groupId>
                 <artifactId>reactor-core</artifactId>
                 <version>${reactor.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>io.projectreactor.ipc</groupId>
-                <artifactId>reactor-netty</artifactId>
-                <version>${reactor-netty.version}</version>
-                <scope>test</scope>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-deployer-spi</artifactId>
+                <version>${spring-cloud-deployer-spi.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
-<profiles>
-		<profile>
-			<id>spring</id>
-			<repositories>
-				<repository>
-					<id>spring-snapshots</id>
-					<name>Spring Snapshots</name>
-					<url>http://repo.spring.io/libs-snapshot-local</url>
-					<snapshots>
-						<enabled>true</enabled>
-					</snapshots>
-				</repository>
-				<repository>
-					<id>spring-milestones</id>
-					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/libs-milestone-local</url>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-				</repository>
-				<repository>
-					<id>spring-releases</id>
-					<name>Spring Releases</name>
-					<url>http://repo.spring.io/release</url>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-				</repository>
-				<repository>
-					<id>spring-libs-release</id>
-					<name>Spring Libs Release</name>
-					<url>http://repo.spring.io/libs-release</url>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-				</repository>
-				<repository>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-					<id>spring-milestone-release</id>
-					<name>Spring Milestone Release</name>
-					<url>http://repo.spring.io/libs-milestone</url>
-				</repository>
-			</repositories>
-			<pluginRepositories>
-				<pluginRepository>
-					<id>spring-snapshots</id>
-					<name>Spring Snapshots</name>
-					<url>http://repo.spring.io/libs-snapshot-local</url>
-					<snapshots>
-						<enabled>true</enabled>
-					</snapshots>
-				</pluginRepository>
-				<pluginRepository>
-					<id>spring-milestones</id>
-					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/libs-milestone-local</url>
-					<snapshots>
-						<enabled>false</enabled>
-					</snapshots>
-				</pluginRepository>
-			</pluginRepositories>
-		</profile>
-	</profiles>
+    <profiles>
+        <profile>
+            <id>spring</id>
+            <repositories>
+                <repository>
+                    <id>spring-snapshots</id>
+                    <name>Spring Snapshots</name>
+                    <url>http://repo.spring.io/libs-snapshot-local</url>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+                <repository>
+                    <id>spring-milestones</id>
+                    <name>Spring Milestones</name>
+                    <url>http://repo.spring.io/libs-milestone-local</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+                <repository>
+                    <id>spring-releases</id>
+                    <name>Spring Releases</name>
+                    <url>http://repo.spring.io/release</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+                <repository>
+                    <id>spring-libs-release</id>
+                    <name>Spring Libs Release</name>
+                    <url>http://repo.spring.io/libs-release</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </repository>
+                <repository>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                    <id>spring-milestone-release</id>
+                    <name>Spring Milestone Release</name>
+                    <url>http://repo.spring.io/libs-milestone</url>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>spring-snapshots</id>
+                    <name>Spring Snapshots</name>
+                    <url>http://repo.spring.io/libs-snapshot-local</url>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </pluginRepository>
+                <pluginRepository>
+                    <id>spring-milestones</id>
+                    <name>Spring Milestones</name>
+                    <url>http://repo.spring.io/libs-milestone-local</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
resolves #4

* Updated documentation
* Removed build exclusion needed when app was under old starter framework
* But now fails with Droplet exception as shown below when running the task-launcher-cloudfoundry from a SCDF local on laptop.  The task launcher
is pointing to PWS.

```
2017-03-17 10:48:33.561 ERROR 24854 --- [ry-client-nio-3] s.c.CloudFoundry2630AndLaterTaskLauncher : Task Task-a5f5d123-262b-4822-acf4-53cdd3b7d63a launch failed

org.cloudfoundry.client.v3.ClientV3Exception: CF-UnprocessableEntity(10008): The request is semantically invalid: Task must have a droplet. Specify droplet or assign current droplet to app.
    at org.cloudfoundry.reactor.util.ErrorPayloadMapper.lambda$null$3(ErrorPayloadMapper.java:65) ~[cloudfoundry-client-reactor-2.4.0.RELEASE.jar!/:2.4.0.RELEASE]
    at org.cloudfoundry.reactor.util.ErrorPayloadMapper.lambda$null$10(ErrorPayloadMapper.java:107) ~[cloudfoundry-client-reactor-2.4.0.RELEASE.jar!/:2.4.0.RELEASE]
    at reactor.core.publisher.MonoThenMap$MonoThenApplyMain.onNext(MonoThenMap.java:100) ~[reactor-core-3.0.5.RELEASE.jar!/:3.0.5.RELEASE]
    at reactor.core.publisher.FluxMap$MapSubscriber.onNext(FluxMap.java:114) ~[reactor-core-3.0.5.RELEASE.jar!/:3.0.5.RELEASE]
    at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:119) ~[reactor-core-3.0.5.RELEASE.jar!/:3.0.5.RELEASE]
    at reactor.core.publisher.FluxUsing$UsingFuseableSubscriber.onNext(FluxUsing.java:320) ~[reactor-core-3.0.5.RELEASE.jar!/:3.0.5.RELEASE]
    at reactor.core.publisher.FluxFilterFuseable$FilterFuseableSubscriber.onNext(FluxFilterFuseable.java:108) ~[reactor-core-3.0.5.RELEASE.jar!/:3.0.5.RELEASE]
    at reactor.core.publisher.FluxPeekFuseable$PeekFuseableConditionalSubscriber.onNext(FluxPeekFuseable.java:412) ~[reactor-core-3.0.5.RELEASE.jar!/:3.0.5.RELEASE]
    at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:928) ~[reactor-core-3.0.5.RELEASE.jar!/:3.0.5.RELEASE]
    at reactor.core.publisher.MonoReduceSeed$ReduceSeedSubscriber.onComplete(MonoReduceSeed.java:142) ~[reactor-core-3.0.5.RELEASE.jar!/:3.0.5.RELEASE]
    at reactor.core.publisher.FluxMap$MapSubscriber.onComplete(FluxMap.java:136) ~[reactor-core-3.0.5.RELEASE.jar!/:3.0.5.RELEASE]
    at reactor.ipc.netty.channel.FluxReceive.onInboundComplete(FluxReceive.java:315) ~[reactor-netty-0.6.0.RELEASE.jar!/:na]
    at reactor.ipc.netty.channel.ChannelOperations.onInboundComplete(ChannelOperations.java:427) ~[reactor-netty-0.6.0.RELEASE.jar!/:na]
    at reactor.ipc.netty.channel.ChannelOperations.onHandlerTerminate(ChannelOperations.java:499) ~[reactor-netty-0.6.0.RELEASE.jar!/:na]
    at reactor.ipc.netty.http.client.HttpClientOperations.onInboundNext(HttpClientOperations.java:469) ~[reactor-netty-0.6.0.RELEASE.jar!/:na]
    at reactor.ipc.netty.channel.ChannelOperationsHandler.channelRead(ChannelOperationsHandler.java:113) ~[reactor-netty-0.6.0.RELEASE.jar!/:na]
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:349) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:341) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:293) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:267) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:349) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:341) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1228) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1039) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:411) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:248) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:349) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:341) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1334) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:349) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:926) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:129) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:642) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:565) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:479) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:441) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:858) ~[netty-all-4.1.8.Final.jar!/:4.1.8.Final]
    at java.lang.Thread.run(Thread.java:745) ~[na:1.8.0_74]
    Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException:
Assembly trace from producer [reactor.core.publisher.MonoPeek] :
    reactor.core.publisher.Mono.checkpoint(Mono.java:1286)
    org.cloudfoundry.reactor.client.v3.tasks.ReactorTasks.create(ReactorTasks.java:58)
    org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundry2630AndLaterTaskLauncher.requestCreateTask(CloudFoundry2630AndLaterTaskLauncher.java:197)
    org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundry2630AndLaterTaskLauncher.launchTask(CloudFoundry2630AndLaterTaskLauncher.java:169)
    org.springframework.cloud.deployer.spi.cloudfoundry.CloudFoundry2630AndLaterTaskLauncher.lambda$launch$0(CloudFoundry2630AndLaterTaskLauncher.java:96)
    reactor.core.publisher.MonoThenMap$MonoThenApplyMain.onNext(MonoThenMap.java:100)
    reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:928)
    reactor.core.publisher.MonoThenMap$MonoThenApplyMain$SecondSubscriber.onNext(MonoThenMap.java:202)
    reactor.core.publisher.FluxPeek$PeekSubscriber.onNext(FluxPeek.java:165)
    reactor.core.publisher.MonoNext$NextSubscriber.onNext(MonoNext.java:78)
    reactor.core.publisher.FluxMap$MapSubscriber.onNext(FluxMap.java:114)
    reactor.core.publisher.MonoFlatMap$FlattenSubscriber$InnerSubscriber.onNext(MonoFlatMap.java:199)
    reactor.core.publisher.FluxMap$MapSubscriber.onNext(FluxMap.java:114)
    reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:119)
    reactor.core.publisher.FluxUsing$UsingFuseableSubscriber.onNext(FluxUsing.java:320)
    reactor.core.publisher.FluxFilterFuseable$FilterFuseableSubscriber.onNext(FluxFilterFuseable.java:108)
    reactor.core.publisher.FluxPeekFuseable$PeekFuseableConditionalSubscriber.onNext(FluxPeekFuseable.java:412)
    reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:928)
    reactor.core.publisher.MonoReduceSeed$ReduceSeedSubscriber.onComplete(MonoReduceSeed.java:142)
    reactor.core.publisher.FluxMap$MapSubscriber.onComplete(FluxMap.java:136)
    reactor.ipc.netty.channel.FluxReceive.onInboundComplete(FluxReceive.java:315)
    reactor.ipc.netty.channel.ChannelOperations.onInboundComplete(ChannelOperations.java:427)
    reactor.ipc.netty.channel.ChannelOperations.onHandlerTerminate(ChannelOperations.java:499)
    reactor.ipc.netty.http.client.HttpClientOperations.onInboundNext(HttpClientOperations.java:469)
    reactor.ipc.netty.channel.ChannelOperationsHandler.channelRead(ChannelOperationsHandler.java:113)
    io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363)
    io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:349)
    io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:341)
    io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:271)
    io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363)
    io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:349)
    io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:341)
    io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:293)
    io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:267)
    io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363)
    io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:349)
    io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:341)
    io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1228)
    io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1039)
    io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:411)
    io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:248)
    io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363)
    io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:349)
    io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:341)
    io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1334)
    io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:363)
    io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:349)
    io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:926)
    io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:129)
    io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:642)
    io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:565)
    io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:479)
    io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:441)
    io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:858)
Error has been observed by the following operator(s):
    |_    Mono.checkpoint(ReactorTasks.java:58)
```