### PR TITLE
Fix version number of Spring Cloud Task

### DIFF
--- a/tasklauncher-cloudfoundry-app-dependencies/pom.xml
+++ b/tasklauncher-cloudfoundry-app-dependencies/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <spring-cloud-deployer-cloudfoundry.version>1.2.0.BUILD-SNAPSHOT</spring-cloud-deployer-cloudfoundry.version>
-        <spring.cloud.task.version>1.1.2.BUILD-SNAPSHOT</spring.cloud.task.version>
+        <spring.cloud.task.version>1.1.2.RELEASE</spring.cloud.task.version>
         <reactor.version>3.0.5.RELEASE</reactor.version>
         <spring-cloud-deployer-spi.version>1.2.0.BUILD-SNAPSHOT</spring-cloud-deployer-spi.version>
     </properties>


### PR DESCRIPTION
Seems there was a hiccup in the last commit that set the version of task from 1.1.2.RELEASE to 1.1.2.BUILD-SNAPSHOT