### PR TITLE
URL Cleanup

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 				<repository>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
-					<url>http://repo.spring.io/libs-snapshot-local</url>
+					<url>https://repo.spring.io/libs-snapshot-local</url>
 					<snapshots>
 						<enabled>true</enabled>
 					</snapshots>
@@ -43,7 +43,7 @@
 				<repository>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/libs-milestone-local</url>
+					<url>https://repo.spring.io/libs-milestone-local</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>
@@ -51,7 +51,7 @@
 				<repository>
 					<id>spring-releases</id>
 					<name>Spring Releases</name>
-					<url>http://repo.spring.io/release</url>
+					<url>https://repo.spring.io/release</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>
@@ -59,7 +59,7 @@
 				<repository>
 					<id>spring-libs-release</id>
 					<name>Spring Libs Release</name>
-					<url>http://repo.spring.io/libs-release</url>
+					<url>https://repo.spring.io/libs-release</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>
@@ -70,15 +70,15 @@
 					</snapshots>
 					<id>spring-milestone-release</id>
 					<name>Spring Milestone Release</name>
-					<url>http://repo.spring.io/libs-milestone</url>
+					<url>https://repo.spring.io/libs-milestone</url>
 				</repository>
 			</repositories>
 			<pluginRepositories>
-<pluginRepository><id>spring-releases></id><name>Spring Releases</name><url>http://repo.spring.io/libs-release</url></pluginRepository>
+<pluginRepository><id>spring-releases></id><name>Spring Releases</name><url>https://repo.spring.io/libs-release</url></pluginRepository>
 				<pluginRepository>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
-					<url>http://repo.spring.io/libs-snapshot-local</url>
+					<url>https://repo.spring.io/libs-snapshot-local</url>
 					<snapshots>
 						<enabled>true</enabled>
 					</snapshots>
@@ -86,7 +86,7 @@
 				<pluginRepository>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/libs-milestone-local</url>
+					<url>https://repo.spring.io/libs-milestone-local</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>

--- a/tasklauncher-cloudfoundry-app-dependencies/pom.xml
+++ b/tasklauncher-cloudfoundry-app-dependencies/pom.xml
@@ -88,7 +88,7 @@
                 <repository>
                     <id>spring-snapshots</id>
                     <name>Spring Snapshots</name>
-                    <url>http://repo.spring.io/libs-snapshot-local</url>
+                    <url>https://repo.spring.io/libs-snapshot-local</url>
                     <snapshots>
                         <enabled>true</enabled>
                     </snapshots>
@@ -96,7 +96,7 @@
                 <repository>
                     <id>spring-milestones</id>
                     <name>Spring Milestones</name>
-                    <url>http://repo.spring.io/libs-milestone-local</url>
+                    <url>https://repo.spring.io/libs-milestone-local</url>
                     <snapshots>
                         <enabled>false</enabled>
                     </snapshots>
@@ -104,7 +104,7 @@
                 <repository>
                     <id>spring-releases</id>
                     <name>Spring Releases</name>
-                    <url>http://repo.spring.io/release</url>
+                    <url>https://repo.spring.io/release</url>
                     <snapshots>
                         <enabled>false</enabled>
                     </snapshots>
@@ -112,7 +112,7 @@
                 <repository>
                     <id>spring-libs-release</id>
                     <name>Spring Libs Release</name>
-                    <url>http://repo.spring.io/libs-release</url>
+                    <url>https://repo.spring.io/libs-release</url>
                     <snapshots>
                         <enabled>false</enabled>
                     </snapshots>
@@ -123,14 +123,14 @@
                     </snapshots>
                     <id>spring-milestone-release</id>
                     <name>Spring Milestone Release</name>
-                    <url>http://repo.spring.io/libs-milestone</url>
+                    <url>https://repo.spring.io/libs-milestone</url>
                 </repository>
             </repositories>
             <pluginRepositories>
                 <pluginRepository>
                     <id>spring-snapshots</id>
                     <name>Spring Snapshots</name>
-                    <url>http://repo.spring.io/libs-snapshot-local</url>
+                    <url>https://repo.spring.io/libs-snapshot-local</url>
                     <snapshots>
                         <enabled>true</enabled>
                     </snapshots>
@@ -138,7 +138,7 @@
                 <pluginRepository>
                     <id>spring-milestones</id>
                     <name>Spring Milestones</name>
-                    <url>http://repo.spring.io/libs-milestone-local</url>
+                    <url>https://repo.spring.io/libs-milestone-local</url>
                     <snapshots>
                         <enabled>false</enabled>
                     </snapshots>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://repo.spring.io/libs-milestone migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/libs-milestone-local migrated to:  
  https://repo.spring.io/libs-milestone-local ([https](https://repo.spring.io/libs-milestone-local) result 302).
* http://repo.spring.io/libs-release migrated to:  
  https://repo.spring.io/libs-release ([https](https://repo.spring.io/libs-release) result 302).
* http://repo.spring.io/libs-snapshot-local migrated to:  
  https://repo.spring.io/libs-snapshot-local ([https](https://repo.spring.io/libs-snapshot-local) result 302).
* http://repo.spring.io/release migrated to:  
  https://repo.spring.io/release ([https](https://repo.spring.io/release) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance