### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/spring-cloud-starter-stream-sink-task-launcher-cloudfoundry/README.adoc
+++ b/spring-cloud-starter-stream-sink-task-launcher-cloudfoundry/README.adoc
@@ -45,7 +45,7 @@ maven repositories, be sure to set the `--maven.remote-repositories` properties.
 For example:
 
 ```
-java -jar task_launcher_cloudfoundry.jar --maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot
+java -jar task_launcher_cloudfoundry.jar --maven.remote-repositories.repo1.url=https://repo.spring.io/libs-snapshot
 ```
 
 //tag::configuration-properties[]
@@ -81,7 +81,7 @@ command line arguments, and deployment properties from the TaskLaunchRequest,
 which it uses to deploy and launch the task.
 
 ```
-java -jar task_launcher_cloudfoundry.jar --maven.remote-repositories.repo1.url=http://repo.spring.io/libs-snapshot \
+java -jar task_launcher_cloudfoundry.jar --maven.remote-repositories.repo1.url=https://repo.spring.io/libs-snapshot \
     --spring.cloud.deployer.cloudfoundry.url=https://api.local.pcfdev.io \
     --spring.cloud.deployer.cloudfoundry.org=user-dataflow \
     --spring.cloud.deployer.cloudfoundry.space=development \


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://repo.spring.io/libs-snapshot with 2 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://hello with 2 occurrences